### PR TITLE
dont publish .babelrc file: breaks react-native projects

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc


### PR DESCRIPTION
Publishing a .babelrc file breaks `react-native` projects using `react-autobind`, as it conflicts with react-native's packager. Removing it from the publishing step solves this.