### PR TITLE
added a lifecycle method as of 16.3.1

### DIFF
--- a/lib/autoBind.js
+++ b/lib/autoBind.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, '__esModule', {
   value: true
 });
 exports['default'] = autoBind;
-var wontBind = ['constructor', 'render', 'componentWillMount', 'componentDidMount', 'componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate', 'componentWillUnmount'];
+var wontBind = ['constructor', 'render', 'componentWillMount', 'componentDidMount', 'componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate', 'componentWillUnmount', 'getDerivedStateFromProps'];
 
 var toBind = [];
 


### PR DESCRIPTION
Might be a good idea to revamp lifecycle wontBind array since these deprecated methods will only continue to work till version 17:

componentWillMount
componentWillReceiveProps
componentWillUpdate

